### PR TITLE
change CI back to use nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - binutils-dev
 
 rust:
-  - nightly-2018-03-26
+  - nightly
 
 before_script:
   - git clone https://github.com/apache/thrift.git


### PR DESCRIPTION
As https://github.com/rust-lang/rust/pull/49518 is merged. We can change CI back to use Rust nightly.