### PR TITLE
Update documentation for write support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and this to your crate root:
 extern crate parquet;
 ```
 
-Example usage:
+Example usage of reading data:
 ```rust
 use std::fs::File;
 use std::path::Path;
@@ -70,7 +70,10 @@ version is available. Then simply update version of `parquet-format` crate in Ca
   - [X] Row record reader
   - [ ] Arrow record reader
 - [X] Statistics support
-- [ ] Write support
+- [X] Write support
+  - [X] Primitive column value writers
+  - [ ] Row record writer
+  - [ ] Arrow record writer
 - [ ] Predicate pushdown
 - [ ] Parquet format 2.5 support
 - [ ] HDFS support

--- a/src/column/mod.rs
+++ b/src/column/mod.rs
@@ -15,13 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Low level column reader API.
+//! Low level column reader and writer APIs.
 //!
-//! This API is designed for the direct mapping with subsequent manual handling of
-//! definition and repetition levels and spacing. This allows to create column vectors
-//! and batches and map them directly to Parquet data.
-//!
-//! See below an example of using the API.
+//! This API is designed for reading and writing column values, definition and repetition
+//! levels directly.
 //!
 //! # Example
 //!

--- a/src/column/mod.rs
+++ b/src/column/mod.rs
@@ -20,75 +20,104 @@
 //! This API is designed for reading and writing column values, definition and repetition
 //! levels directly.
 //!
-//! # Example
+//! # Example of writing and reading data
+//!
+//! Data has the following format:
+//! ```text
+//! +---------------+
+//! |         values|
+//! +---------------+
+//! |[1, 2]         |
+//! |[3, null, null]|
+//! +---------------+
+//! ```
+//!
+//! The example uses column writer and reader APIs to write raw values, definition and
+//! repetition levels and read them to verify write/read correctness.
 //!
 //! ```rust
-//! use std::fs::File;
+//! use std::fs;
 //! use std::path::Path;
+//! use std::rc::Rc;
 //!
-//! use parquet::basic::Type;
-//! use parquet::data_type::Int32Type;
-//! use parquet::column::reader::get_typed_column_reader;
+//! use parquet::column::reader::ColumnReader;
+//! use parquet::column::writer::ColumnWriter;
+//! use parquet::file::properties::WriterProperties;
 //! use parquet::file::reader::{FileReader, SerializedFileReader};
+//! use parquet::file::writer::{FileWriter, SerializedFileWriter};
+//! use parquet::schema::parser::parse_message_type;
 //!
-//! // Open Parquet file and initialize reader
-//! let path = Path::new("data/alltypes_plain.parquet");
-//! let file = File::open(&path).unwrap();
-//! let parquet_reader = SerializedFileReader::new(file).unwrap();
-//! let metadata = parquet_reader.metadata();
+//! let path = Path::new("target/debug/examples/column_sample.parquet");
 //!
-//! for i in 0..metadata.num_row_groups() {
-//!   let row_group_reader = parquet_reader.get_row_group(i).unwrap();
-//!   let row_group_metadata = metadata.row_group(i);
+//! // Writing data using column writer API.
 //!
-//!   for j in 0..row_group_metadata.num_columns() {
-//!     let column = row_group_metadata.column(j);
-//!
-//!     // Extract column reader and map to typed column reader for required columns.
-//!     let column_reader = row_group_reader
-//!       .get_column_reader(j)
-//!       .expect("Valid column reader");
-//!
-//!     // Extract typed column reader for any INT32 column in the file.
-//!     // It is also possible to extract certain columns based on column descriptors
-//!     // from metadata.
-//!
-//!     match column.column_type() {
-//!       Type::INT32 => {
-//!         let mut typed_column_reader =
-//!           get_typed_column_reader::<Int32Type>(column_reader);
-//!
-//!         // See `read_batch` method for comments on different parameters.
-//!         let mut values = vec![0; 16];
-//!         let mut def_levels = vec![0; 16];
-//!         let mut rep_levels = vec![0; 16];
-//!
-//!         let num_values = typed_column_reader.read_batch(
-//!           8, // batch size
-//!           Some(&mut def_levels), // definition levels
-//!           Some(&mut rep_levels), // repetition levels
-//!           &mut values // read values
-//!         );
-//!
-//!         println!(
-//!           "Read {:?} values, values: {:?}, def_levels: {:?}, rep_levels: {:?}",
-//!           num_values,
-//!           values,
-//!           def_levels,
-//!           rep_levels,
-//!         );
-//!       },
-//!       _ => {
-//!         // Skip any other columns for now, but there could be similar processing.
-//!         println!(
-//!           "Skipped column {} of type {}",
-//!           column.column_path().string(),
-//!           column.column_type()
-//!         );
+//! let message_type = "
+//!   message schema {
+//!     optional group values (LIST) {
+//!       repeated group list {
+//!         optional INT32 element;
 //!       }
 //!     }
 //!   }
+//! ";
+//! let schema = Rc::new(parse_message_type(message_type).unwrap());
+//! let props = Rc::new(WriterProperties::builder().build());
+//! let file = fs::File::create(path).unwrap();
+//! let mut writer = SerializedFileWriter::new(file, schema, props).unwrap();
+//! let mut row_group_writer = writer.next_row_group().unwrap();
+//! while let Some(mut col_writer) = row_group_writer.next_column().unwrap() {
+//!   match col_writer {
+//!     // You can also use `get_typed_column_writer` method to extract typed writer.
+//!     ColumnWriter::Int32ColumnWriter(ref mut typed_writer) => {
+//!       typed_writer.write_batch(
+//!         &[1, 2, 3],
+//!         Some(&[3, 3, 3, 2, 2]),
+//!         Some(&[0, 1, 0, 1, 1])
+//!       ).unwrap();
+//!     },
+//!     _ => { }
+//!   }
+//!   row_group_writer.close_column(col_writer).unwrap();
 //! }
+//! writer.close_row_group(row_group_writer).unwrap();
+//! writer.close().unwrap();
+//!
+//! // Reading data using column reader API.
+//!
+//! let file = fs::File::open(path).unwrap();
+//! let reader = SerializedFileReader::new(file).unwrap();
+//! let metadata = reader.metadata();
+//!
+//! let mut res = Ok((0, 0));
+//! let mut values = vec![0; 8];
+//! let mut def_levels = vec![0; 8];
+//! let mut rep_levels = vec![0; 8];
+//!
+//! for i in 0..metadata.num_row_groups() {
+//!   let row_group_reader = reader.get_row_group(i).unwrap();
+//!   let row_group_metadata = metadata.row_group(i);
+//!
+//!   for j in 0..row_group_metadata.num_columns() {
+//!     let mut column_reader = row_group_reader.get_column_reader(j).unwrap();
+//!     match column_reader {
+//!       // You can also use `get_typed_column_reader` method to extract typed reader.
+//!       ColumnReader::Int32ColumnReader(ref mut typed_reader) => {
+//!         res = typed_reader.read_batch(
+//!           8, // batch size
+//!           Some(&mut def_levels),
+//!           Some(&mut rep_levels),
+//!           &mut values
+//!         );
+//!       },
+//!       _ => { }
+//!     }
+//!   }
+//! }
+//!
+//! assert_eq!(res, Ok((3, 5)));
+//! assert_eq!(values, vec![1, 2, 3, 0, 0, 0, 0, 0]);
+//! assert_eq!(def_levels, vec![3, 3, 3, 2, 2, 0, 0, 0]);
+//! assert_eq!(rep_levels, vec![0, 1, 0, 1, 1, 0, 0, 0]);
 //! ```
 
 pub mod page;

--- a/src/column/writer.rs
+++ b/src/column/writer.rs
@@ -179,11 +179,11 @@ impl<T: DataType> ColumnWriterImpl<T> {
   /// select how many values to write (this number will be returned), since number of
   /// actual written values may be smaller than provided values.
   ///
-  /// If only values are provided, then we write all values, and return the length of
-  /// of the values buffer.
+  /// If only values are provided, then all values are written and the length of
+  /// of the values buffer is returned.
   ///
-  /// Definition and/or repetition levels can be omitted, if values are either
-  /// non-nullable or non-repeated.
+  /// Definition and/or repetition levels can be omitted, if values are
+  /// non-nullable and/or non-repeated.
   pub fn write_batch(
     &mut self,
     values: &[T::T],

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -16,11 +16,12 @@
 // under the License.
 
 //! Main entrypoint for working with Parquet API.
-//! Provides access to file and row group readers, record API, etc.
 //!
-//! See [`reader::SerializedFileReader`] for a starting reference,
-//! [`metadata::ParquetMetaData`] for file metadata, and [`statistics`] for working
-//! with statistics.
+//! Provides access to file and row group readers and writers, record API, metadata, etc.
+//!
+//! See [`reader::SerializedFileReader`] or [`writer::SerializedFileWriter`] for a
+//! starting reference, [`metadata::ParquetMetaData`] for file metadata,
+//! and [`statistics`] for working with statistics.
 //!
 //! # Example
 //!

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -44,12 +44,15 @@
 //! # Example of writing a new file
 //!
 //! ```rust
-//! use std::fs;
+//!use std::fs;
 //! use std::path::Path;
 //! use std::rc::Rc;
+//!
 //! use parquet::file::properties::WriterProperties;
 //! use parquet::file::writer::{FileWriter, SerializedFileWriter};
 //! use parquet::schema::parser::parse_message_type;
+//!
+//! let path = Path::new("target/debug/examples/sample.parquet");
 //!
 //! let message_type = "
 //!   message schema {
@@ -57,12 +60,8 @@
 //!   }
 //! ";
 //! let schema = Rc::new(parse_message_type(message_type).unwrap());
-//!
 //! let props = Rc::new(WriterProperties::builder().build());
-//!
-//! let path = Path::new("target/debug/examples/sample.parquet");
 //! let file = fs::File::create(&path).unwrap();
-//!
 //! let mut writer = SerializedFileWriter::new(file, schema, props).unwrap();
 //! let mut row_group_writer = writer.next_row_group().unwrap();
 //! while let Some(mut col_writer) = row_group_writer.next_column().unwrap() {

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -23,7 +23,7 @@
 //! starting reference, [`metadata::ParquetMetaData`] for file metadata,
 //! and [`statistics`] for working with statistics.
 //!
-//! # Example
+//! # Example of reading an existing file
 //!
 //! ```rust
 //! use std::fs::File;
@@ -39,6 +39,41 @@
 //!
 //! let row_group_reader = reader.get_row_group(0).unwrap();
 //! assert_eq!(row_group_reader.num_columns(), 11);
+//! ```
+//!
+//! # Example of writing a new file
+//!
+//! ```rust
+//! use std::fs;
+//! use std::path::Path;
+//! use std::rc::Rc;
+//! use parquet::file::properties::WriterProperties;
+//! use parquet::file::writer::{FileWriter, SerializedFileWriter};
+//! use parquet::schema::parser::parse_message_type;
+//!
+//! let message_type = "
+//!   message schema {
+//!     REQUIRED INT32 b;
+//!   }
+//! ";
+//! let schema = Rc::new(parse_message_type(message_type).unwrap());
+//!
+//! let props = Rc::new(WriterProperties::builder().build());
+//!
+//! let path = Path::new("target/debug/examples/sample.parquet");
+//! let file = fs::File::create(&path).unwrap();
+//!
+//! let mut writer = SerializedFileWriter::new(file, schema, props).unwrap();
+//! let mut row_group_writer = writer.next_row_group().unwrap();
+//! while let Some(mut col_writer) = row_group_writer.next_column().unwrap() {
+//!   // ... write values to a column writer
+//!   row_group_writer.close_column(col_writer).unwrap();
+//! }
+//! writer.close_row_group(row_group_writer).unwrap();
+//! writer.close().unwrap();
+//!
+//! let bytes = fs::read(&path).unwrap();
+//! assert_eq!(&bytes[0..4], &[b'P', b'A', b'R', b'1']);
 //! ```
 
 pub mod metadata;

--- a/src/file/reader.rs
+++ b/src/file/reader.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Contains file reader API, and provides methods to access file metadata, row group
+//! Contains file reader API and provides methods to access file metadata, row group
 //! readers to read individual column chunks, or access record iterator.
 
 use std::convert::TryFrom;

--- a/src/file/statistics.rs
+++ b/src/file/statistics.rs
@@ -33,7 +33,7 @@
 //!     assert_eq!(*typed.min(), 1);
 //!     assert_eq!(*typed.max(), 10);
 //!   },
-//!   _ => panic!()
+//!   _ => { }
 //! }
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! assembly algorithm described in the Dremel paper.
 //!
 //! Crate provides API to access file schema and metadata from a Parquet file, extract
-//! row groups or column chunks from a file, and read records/values.
+//! row groups or column chunks from a file, read and write records/values.
 //!
 //! # Usage
 //!
@@ -57,8 +57,8 @@
 //! assert_eq!(schema.get_fields().len(), 11);
 //! ```
 //!
-//! Crate offers several [read API options](#read-api), the simplest one is getting
-//! record reader directly, see below:
+//! Crate provides several [read](#read-api) and [write](#write-api) API options. Below
+//! is an example of using the record reader API.
 //!
 //! ```
 //! #![feature(try_from)]
@@ -68,7 +68,7 @@
 //!
 //! let reader = SerializedFileReader::try_from("data/alltypes_plain.parquet").unwrap();
 //!
-//! // Reading data using record API, optional projection schema can be passed as well.
+//! // Reading data using record API with optional projection schema.
 //! let mut iter = reader.get_row_iter(None).unwrap();
 //! while let Some(record) = iter.next() {
 //!   // See record API for different field accessors
@@ -112,6 +112,13 @@
 //! - Low level column reader API (see [`file`] and [`column`] modules)
 //! - Arrow API (_TODO_)
 //! - High level record API (see [`record`] module)
+//!
+//! # Write API
+//!
+//! Crate also provides API to write data in Parquet format:
+//! - Low level column writer API (see [`file`] and [`column`] modules)
+//! - Arrow API (_TODO_)
+//! - High level API for writing records (_TODO_)
 
 #![feature(type_ascription)]
 #![feature(rustc_private)]


### PR DESCRIPTION
This PR updates documentation and rustdoc with write support updates:
- Write support mentioning in the main README
- Rust documentation updates for write structs, traits and methods
- Rust documentation example updates to include write examples
- Minor changes and simplifications