### PR TITLE
Upgraded rand 0.4 -> 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ num-bigint = "0.2"
 
 [dev-dependencies]
 lazy_static = "1"
-rand = "0.4"
+rand = "0.5"

--- a/src/encodings/rle.rs
+++ b/src/encodings/rle.rs
@@ -497,7 +497,7 @@ impl RleDecoder {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use rand::{self, thread_rng, Rng, SeedableRng };
+  use rand::{self, thread_rng, Rng, SeedableRng};
   use rand::distributions::{Distribution, Standard};
   use util::memory::ByteBufferPtr;
 
@@ -778,9 +778,8 @@ mod tests {
       values.clear();
       let mut rng = thread_rng();
       let seed_vec : Vec<u8> = Standard.sample_iter(&mut rng).take(seed_len).collect();
-      let seed_slice = &seed_vec[0..32];
       let mut seed = [0u8; 32];
-      seed.copy_from_slice(seed_slice);
+      seed.copy_from_slice(&seed_vec[0..seed_len]);
       let mut gen = rand::StdRng::from_seed(seed);
 
       let mut parity = false;

--- a/src/encodings/rle.rs
+++ b/src/encodings/rle.rs
@@ -497,7 +497,8 @@ impl RleDecoder {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use rand::{self, thread_rng, Rng, SeedableRng};
+  use rand::{self, thread_rng, Rng, SeedableRng };
+  use rand::distributions::{Distribution, Standard};
   use util::memory::ByteBufferPtr;
 
   const MAX_WIDTH: usize = 32;
@@ -767,7 +768,7 @@ mod tests {
 
   #[test]
   fn test_random() {
-    let seed_len = 10;
+    let seed_len = 32;
     let niters = 50;
     let ngroups = 1000;
     let max_group_size = 15;
@@ -776,8 +777,11 @@ mod tests {
     for _ in 0..niters {
       values.clear();
       let mut rng = thread_rng();
-      let seed = rng.gen_iter::<usize>().take(seed_len).collect::<Vec<usize>>();
-      let mut gen = rand::StdRng::from_seed(&seed[..]);
+      let seed_vec : Vec<u8> = Standard.sample_iter(&mut rng).take(seed_len).collect();
+      let seed_slice = &seed_vec[0..32];
+      let mut seed = [0u8; 32];
+      seed.copy_from_slice(seed_slice);
+      let mut gen = rand::StdRng::from_seed(seed);
 
       let mut parity = false;
       for _ in 0..ngroups {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ extern crate lz4;
 extern crate num_bigint;
 extern crate zstd;
 
+#[cfg(test)]
 extern crate rand;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,6 @@ extern crate lz4;
 extern crate num_bigint;
 extern crate zstd;
 
-#[cfg(test)]
 extern crate rand;
 
 #[macro_use]

--- a/src/util/bit_util.rs
+++ b/src/util/bit_util.rs
@@ -22,6 +22,9 @@ use errors::{ParquetError, Result};
 use util::bit_packing::unpack32;
 use util::memory::ByteBufferPtr;
 
+#[cfg(test)]
+use rand::distributions::{ Distribution, Standard };
+
 /// Reads `$size` of bytes from `$src`, and reinterprets them as type `$ty`, in
 /// little-endian order. `$ty` must implement the `Default` trait. Otherwise this won't
 /// compile.
@@ -610,7 +613,6 @@ impl From<Vec<u8>> for BitReader {
 
 #[cfg(test)]
 mod tests {
-  use rand::Rand;
   use std::fmt::Debug;
 
   use super::super::memory::ByteBufferPtr;
@@ -928,7 +930,7 @@ mod tests {
   }
 
   fn test_put_aligned_rand_numbers<T>(total: usize, num_bits: usize)
-      where T: Copy + Rand + Default + Debug + PartialEq {
+      where T: Copy + Default + Debug + PartialEq, Standard: Distribution<T> {
     assert!(num_bits <= 32);
     assert!(total % 2 == 0);
 

--- a/src/util/bit_util.rs
+++ b/src/util/bit_util.rs
@@ -22,9 +22,6 @@ use errors::{ParquetError, Result};
 use util::bit_packing::unpack32;
 use util::memory::ByteBufferPtr;
 
-#[cfg(test)]
-use rand::distributions::{ Distribution, Standard };
-
 /// Reads `$size` of bytes from `$src`, and reinterprets them as type `$ty`, in
 /// little-endian order. `$ty` must implement the `Default` trait. Otherwise this won't
 /// compile.
@@ -618,6 +615,8 @@ mod tests {
   use super::super::memory::ByteBufferPtr;
   use super::super::test_common::*;
   use super::*;
+
+  use rand::distributions::{ Distribution, Standard };
 
   #[test]
   fn test_ceil() {

--- a/src/util/test_common.rs
+++ b/src/util/test_common.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use rand::{thread_rng, Rng};
-use rand::distributions::range::SampleRange;
 use rand::distributions::{Distribution, Standard};
+use rand::distributions::range::SampleRange;
 use std::env;
 use std::fs;
 use std::io::Write;

--- a/src/util/test_common.rs
+++ b/src/util/test_common.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use rand::{thread_rng, Rng, Rand};
+use rand::{thread_rng, Rng};
 use rand::distributions::range::SampleRange;
+use rand::distributions::{Distribution, Standard};
 use std::env;
 use std::fs;
 use std::io::Write;
@@ -129,13 +130,9 @@ pub fn random_bools(n: usize) -> Vec<bool> {
   result
 }
 
-pub fn random_numbers<T: Rand>(n: usize) -> Vec<T> {
-  let mut result = vec![];
+pub fn random_numbers<T>(n: usize) -> Vec<T> where Standard: Distribution<T> {
   let mut rng = thread_rng();
-  for _ in 0..n {
-    result.push(rng.gen::<T>());
-  }
-  result
+  Standard.sample_iter(&mut rng).take(n).collect()
 }
 
 pub fn random_numbers_range<T>(


### PR DESCRIPTION
I was starting a new project with dependencies that dragged in rand 0.5. This was breaking parquet-rs. I don't know the rand library very well but it looks like there has been a change for how the Standard/Distribution work and it creeped in to parquet-rs.

Should fix: https://github.com/sunchao/parquet-rs/issues/166
And should answer my question at: https://github.com/rust-random/rand/issues/626