### PR TITLE
Improve performance of record reader by using Vec::with_capacity

### DIFF
--- a/src/record/reader.rs
+++ b/src/record/reader.rs
@@ -67,11 +67,13 @@ impl TreeBuilder {
       paths.insert(col_path, col_index);
     }
 
+    let fields = descr.root_schema().get_fields();
+
     // Build child readers for the message type
-    let mut readers = Vec::new();
+    let mut readers = Vec::with_capacity(fields.len());
     let mut path = Vec::new();
 
-    for field in descr.root_schema().get_fields() {
+    for field in fields {
       let reader =
         self.reader_tree(field.clone(), &mut path, 0, 0, &paths, row_group_reader);
       readers.push(reader);
@@ -275,7 +277,7 @@ impl TreeBuilder {
         },
         // Group types (structs)
         _ => {
-          let mut readers = Vec::new();
+          let mut readers = Vec::with_capacity(field.get_fields().len());
           for child in field.get_fields() {
             let reader = self.reader_tree(
               child.clone(),
@@ -380,7 +382,7 @@ impl Reader {
   fn read(&mut self) -> Row {
     match *self {
       Reader::GroupReader(_, _, ref mut readers) => {
-        let mut fields = Vec::new();
+        let mut fields = Vec::with_capacity(readers.len());
         for reader in readers {
           fields.push((String::from(reader.field_name()), reader.read_field()));
         }
@@ -408,7 +410,7 @@ impl Reader {
         }
       },
       Reader::GroupReader(_, def_level, ref mut readers) => {
-        let mut fields = Vec::new();
+        let mut fields = Vec::with_capacity(readers.len());
         for reader in readers {
           if reader.repetition() != Repetition::OPTIONAL
             || reader.current_def_level() > def_level


### PR DESCRIPTION
This PR is a very minor update to the code that we planned to do a few months ago. We basically replace all `Vec::new` with `Vec::with_capacity` wherever it is possible. This shows a fairly small boost in performance, but it is nice to have it.

Before:
```
test record_reader_10k_collect             ... bench:  41,606,845 ns/iter (+/- 2,679,661) = 16 MB/s
test record_reader_stock_simulated_collect ... bench: 341,853,174 ns/iter (+/- 52,464,363) = 3 MB/s
test record_reader_stock_simulated_column  ... bench:  14,812,884 ns/iter (+/- 856,897) = 87 MB/s
```

After:
```
test record_reader_10k_collect             ... bench:  36,193,855 ns/iter (+/- 2,259,012) = 18 MB/s
test record_reader_stock_simulated_collect ... bench: 261,540,852 ns/iter (+/- 10,225,835) = 4 MB/s
test record_reader_stock_simulated_column  ... bench:  18,913,039 ns/iter (+/- 296,384) = 68 MB/s
```

I am not sure why `record_reader_stock_simulated_column` is slower, this change should not affect the benchmark at all.